### PR TITLE
Add DUSK

### DIFF
--- a/wm-class-database.json
+++ b/wm-class-database.json
@@ -66,6 +66,7 @@
     "466910": "wormis.exe",
     "514900": "TheObserver-Linux-Shipping",
     "515220": "F12017",
+    "519860": "DUSK.x86_64",
     "544330": "snakepass-win64-shipping.exe",
     "554620": ["LifeIsStrangeBTS", "Life is Strange Before the Storm"],
     "628950": "nephisebegins-win64-shipping.exe",


### PR DESCRIPTION
https://store.steampowered.com/app/519860/DUSK/

```
$ xprop
_NET_WM_USER_TIME(CARDINAL) = 57260030
_NET_WM_ICON(CARDINAL) = 	Icon (128 x 128):
	(not shown)

_NET_WM_STATE(ATOM) = 
WM_STATE(WM_STATE):
		window state: Normal
		icon window: 0x0
_NET_WM_DESKTOP(CARDINAL) = 2
_GTK_EDGE_CONSTRAINTS(CARDINAL) = 170
_NET_FRAME_EXTENTS(CARDINAL) = 0, 0, 36, 0
_NET_WM_ALLOWED_ACTIONS(ATOM) = _NET_WM_ACTION_MOVE, _NET_WM_ACTION_RESIZE, _NET_WM_ACTION_FULLSCREEN, _NET_WM_ACTION_MINIMIZE, _NET_WM_ACTION_SHADE, _NET_WM_ACTION_MAXIMIZE_HORZ, _NET_WM_ACTION_MAXIMIZE_VERT, _NET_WM_ACTION_CHANGE_DESKTOP, _NET_WM_ACTION_CLOSE, _NET_WM_ACTION_ABOVE, _NET_WM_ACTION_BELOW
_NET_WM_NAME(UTF8_STRING) = "Dusk"
WM_NAME(STRING) = "Dusk"
XdndAware(ATOM) = BITMAP
WM_PROTOCOLS(ATOM): protocols  WM_DELETE_WINDOW, WM_TAKE_FOCUS, _NET_WM_PING
_NET_WM_BYPASS_COMPOSITOR(CARDINAL) = 1
_NET_WM_WINDOW_TYPE(ATOM) = _NET_WM_WINDOW_TYPE_NORMAL
_NET_WM_PID(CARDINAL) = 313035
WM_LOCALE_NAME(STRING) = "C"
WM_CLASS(STRING) = "DUSK.x86_64", "DUSK.x86_64"
WM_HINTS(WM_HINTS):
		Client accepts input or input focus: True
		window id # of group leader: 0x3acf95b
WM_NORMAL_HINTS(WM_SIZE_HINTS):
		user specified location: 0, 0
WM_CLIENT_MACHINE(STRING) = "mi15"
_MOTIF_WM_HINTS(_MOTIF_WM_HINTS) = 0x2, 0x0, 0x1, 0x0, 0x0
```

as a bonus, github decided to add a \n at EOF