### PR TITLE
fix crash when appid not found in manifest

### DIFF
--- a/sif.py
+++ b/sif.py
@@ -99,7 +99,8 @@ def get_installed_games(libraries):
                         app_id = line.split('"')[3]
                     elif '"name"' in line:
                         app_name = line.split('"')[3]
-                found_games[app_id] = app_name
+                if app_id:
+                    found_games[app_id] = app_name
     return found_games
 
 


### PR DESCRIPTION
fixes this crash

```
Traceback (most recent call last):
  File "/usr/bin/sif", line 524, in <module>
    sorted(
  File "/usr/bin/sif", line 525, in <lambda>
    get_installed_games(library_folders).items(), key=lambda item: int(item[0])
ValueError: invalid literal for int() with base 10: ''
```