### PR TITLE
Added UNDERTALE and Pillars of Eternity (native linux) to database.json

### DIFF
--- a/database.json
+++ b/database.json
@@ -108,12 +108,14 @@
     "282070": "This War of Mine",
     "286690": "Metro: Redux",
     "287390": "Metro: Redux=Metro: Last Light Redux",
+    "291650": "Pillars of Eternity",
     "317400": "Portal Stories: Mel - OpenGL",
     "322680": "BLACKHOLE",
     "323320": "Grow Home",
     "368230": "Kingdom",
     "375320": "Colortone",
     "378610": "Valley",
+    "391540": "UNDERTALE",
     "391720": "Layers of Fear",
     "415200": "Motorsport Manager",
     "441670": "Jelly Killer",
@@ -121,8 +123,6 @@
     "447530": "VA-11 Hall-A: Cyberpunk Bartender Action",
     "465760": "scrap-garden",
     "583760": "Slash It 2",
-    "867290": "Crossroads Inn",
-    "391540": "UNDERTALE",
-    "291650": "Pillars of Eternity"
+    "867290": "Crossroads Inn"
   }
 }

--- a/database.json
+++ b/database.json
@@ -121,6 +121,8 @@
     "447530": "VA-11 Hall-A: Cyberpunk Bartender Action",
     "465760": "scrap-garden",
     "583760": "Slash It 2",
-    "867290": "Crossroads Inn"
+    "867290": "Crossroads Inn",
+    "391540": "UNDERTALE",
+    "291650": "Pillars of Eternity"
   }
 }

--- a/sif.py
+++ b/sif.py
@@ -210,6 +210,8 @@ def fix_launch_option(app_id, wm_name, wm_name_alt=""):
                     wm_name,
                     wm_name_alt,
                 )
+            elif wm_name == "Pillars of Eternity":
+                app["LaunchOptions"] += '& sleep 5 && %s "%s";' % (script, wm_name)
             else:
                 app["LaunchOptions"] += '& %s "%s";' % (script, wm_name)
         vdf.dump(loaded, open(conf_file, "w"), pretty=True)


### PR DESCRIPTION
Note that Pillars behaves oddly on launch; it opens and closes a few times due to how it handles the intro video. This is fixable by delaying the usage of fix-wm-class.sh. I achieved this by changing the launch options to `%command% & sleep 5 && fix-wm-class.sh "Pillars of Eternity";` If this is not acceptable, I can perhaps find a way to work that into the actual sif.sh script. Just let me know.