### PR TITLE
Made fix-wm-class.sh run as long as game is running.

### DIFF
--- a/fix-wm-class.sh
+++ b/fix-wm-class.sh
@@ -1,3 +1,7 @@
 #!/bin/sh
 WM_CLASS="$([ "$2" ] && echo "$2" || echo "$1")"
-xdotool search --sync --name "$1" set_window --classname "$WM_CLASS" --class "$WM_CLASS" %@
+reaper_pid=$(pidof reaper)
+while kill -0 $reaper_pid 2> /dev/null; do
+    xdotool search --sync --name "$1" set_window --classname "$WM_CLASS" --class "$WM_CLASS" %@
+    sleep 1
+done

--- a/fix-wm-class.sh
+++ b/fix-wm-class.sh
@@ -1,7 +1,15 @@
 #!/bin/sh
-WM_CLASS="$([ "$2" ] && echo "$2" || echo "$1")"
-reaper_pid=$(pidof reaper)
-while kill -0 $reaper_pid 2> /dev/null; do
-    xdotool search --sync --name "$1" set_window --classname "$WM_CLASS" --class "$WM_CLASS" %@
+LOG_FILE="/tmp/wmfix.log"
+LAST=${@:$#}
+WM_CLASS="$LAST"
+echo "Starting process: $@" > $LOG_FILE
+echo "Window Class: $WM_CLASS" >> $LOG_FILE
+"$@" &
+PID=$!
+echo "Process ID: $PID" >> $LOG_FILE
+while kill -0 $PID 2> /dev/null; do
+    echo "Process still running: $(date)" >> $LOG_FILE
+    xdotool search --sync --name "$LAST" set_window --classname "$WM_CLASS" --class "$WM_CLASS" %@
     sleep 1
 done
+echo "Process ended: $(date)" >> $LOG_FILE

--- a/fix-wm-class.sh
+++ b/fix-wm-class.sh
@@ -1,19 +1,25 @@
-#!/bin/sh
-WM_CLASS="$([ "$3" ] && echo "$3" || echo "$2")"
-WM_NAME=$2
-echo $WM_CLASS > "/tmp/wmlog.log"
-echo $WM_NAME >> "/tmp/wmlog.log"
-echo $1 >> "/tmp/wmlog.log"
-COMMAND=$(echo $1 | tr -d "'")
-set -- "${COMMAND}"
-echo $@ >> "/tmp/wmlog.log"
-$@ &
+#!/usr/bin/env sh
+
+LOG_FILE="/tmp/steam_watcher.log"
+
+WM_NAME=$1
+echo "WM_NAME: $WM_NAME" > $LOG_FILE
+shift
+WM_NAME_ALT=$1
+echo "WM_NAME_ALT: $WM_NAME_ALT" >> $LOG_FILE
+shift
+
+WM_CLASS=$WM_NAME_ALT
+
+echo "Starting process: $@" >> $LOG_FILE
+"$@" &
+
 PID=$!
-echo $PID >> "/tmp/wmlog.log"
+echo "Process ID: $PID" >> $LOG_FILE
+
 while kill -0 $PID 2> /dev/null; do
-    xdotool search --sync --name "$WM_NAME" set_window --classname "$WM_CLASS" --class "$WM_CLASS" %@
-    echo "Still running $PID! at $(date)!" >> "/tmp/wmlog.log"
-    sleep 1
+        xdotool search --sync --name "$WM_NAME" set_window --classname "$WM_CLASS" --class "$WM_CLASS" %@
+        echo "Process still running: $(date)" >> $LOG_FILE
+        sleep 1
 done
-echo "Completed execution at $(date)!" >> "/tmp/wmlog.log"
 exit 0

--- a/fix-wm-class.sh
+++ b/fix-wm-class.sh
@@ -3,7 +3,6 @@ LAST=${@:$#}
 WM_CLASS="$LAST"
 "$@" &
 PID=$!
-echo "Process ID: $PID" >> $LOG_FILE
 while kill -0 $PID 2> /dev/null; do
     xdotool search --sync --name "$LAST" set_window --classname "$WM_CLASS" --class "$WM_CLASS" %@
     sleep 1

--- a/fix-wm-class.sh
+++ b/fix-wm-class.sh
@@ -1,9 +1,19 @@
 #!/bin/sh
-LAST=${@:$#}
-WM_CLASS="$LAST"
-"$@" &
+WM_CLASS="$([ "$3" ] && echo "$3" || echo "$2")"
+WM_NAME=$2
+echo $WM_CLASS > "/tmp/wmlog.log"
+echo $WM_NAME >> "/tmp/wmlog.log"
+echo $1 >> "/tmp/wmlog.log"
+COMMAND=$(echo $1 | tr -d "'")
+set -- "${COMMAND}"
+echo $@ >> "/tmp/wmlog.log"
+$@ &
 PID=$!
+echo $PID >> "/tmp/wmlog.log"
 while kill -0 $PID 2> /dev/null; do
-    xdotool search --sync --name "$LAST" set_window --classname "$WM_CLASS" --class "$WM_CLASS" %@
+    xdotool search --sync --name "$WM_NAME" set_window --classname "$WM_CLASS" --class "$WM_CLASS" %@
+    echo "Still running $PID! at $(date)!" >> "/tmp/wmlog.log"
     sleep 1
 done
+echo "Completed execution at $(date)!" >> "/tmp/wmlog.log"
+exit 0

--- a/fix-wm-class.sh
+++ b/fix-wm-class.sh
@@ -1,15 +1,10 @@
 #!/bin/sh
-LOG_FILE="/tmp/wmfix.log"
 LAST=${@:$#}
 WM_CLASS="$LAST"
-echo "Starting process: $@" > $LOG_FILE
-echo "Window Class: $WM_CLASS" >> $LOG_FILE
 "$@" &
 PID=$!
 echo "Process ID: $PID" >> $LOG_FILE
 while kill -0 $PID 2> /dev/null; do
-    echo "Process still running: $(date)" >> $LOG_FILE
     xdotool search --sync --name "$LAST" set_window --classname "$WM_CLASS" --class "$WM_CLASS" %@
     sleep 1
 done
-echo "Process ended: $(date)" >> $LOG_FILE

--- a/sif.py
+++ b/sif.py
@@ -724,7 +724,7 @@ if __name__ == "__main__":
         if steam_detected:
             print_warning("\nSome games couldn't be fixed due to running Steam.\nExit Steam and try it again.")
         else:
-            print("\n * - added fix to game launch options. Please double check to ensure your launch options are correct.")
+            print("\n * - added fix to game launch options. Double check your launch options just in case.")
 
     if options.pretend:
         print_warning("\nNo changes were made because --pretend option was used.")

--- a/sif.py
+++ b/sif.py
@@ -210,8 +210,6 @@ def fix_launch_option(app_id, wm_name, wm_name_alt=""):
                     wm_name,
                     wm_name_alt,
                 )
-            # elif wm_name == "Pillars of Eternity":
-            #     app["LaunchOptions"] += '& sleep 5 && %s "%s";' % (script, wm_name)
             else:
                 app["LaunchOptions"] += '& %s "%s";' % (script, wm_name)
         vdf.dump(loaded, open(conf_file, "w"), pretty=True)

--- a/sif.py
+++ b/sif.py
@@ -210,8 +210,8 @@ def fix_launch_option(app_id, wm_name, wm_name_alt=""):
                     wm_name,
                     wm_name_alt,
                 )
-            elif wm_name == "Pillars of Eternity":
-                app["LaunchOptions"] += '& sleep 5 && %s "%s";' % (script, wm_name)
+            # elif wm_name == "Pillars of Eternity":
+            #     app["LaunchOptions"] += '& sleep 5 && %s "%s";' % (script, wm_name)
             else:
                 app["LaunchOptions"] += '& %s "%s";' % (script, wm_name)
         vdf.dump(loaded, open(conf_file, "w"), pretty=True)

--- a/sif.py
+++ b/sif.py
@@ -202,16 +202,19 @@ def fix_launch_option(app_id, wm_name, wm_name_alt=""):
             app = apps[app_id]
             if "LaunchOptions" not in app.keys():
                 app["LaunchOptions"] = ""
-            app["LaunchOptions"] = sub("&\\s/.*fix-wm-class\\.sh.*?;", "", app["LaunchOptions"])
+            app["LaunchOptions"] = sub("\\s/.*fix-wm-class\\.sh.*?;", "", app["LaunchOptions"])
+            app["LaunchOptions"] = sub("%command%", "", app["LaunchOptions"])
+            launch_options = app["LaunchOptions"].strip()
             script = str(WM_CLASS_FIXER_SCRIPT)
             if wm_name_alt:
-                app["LaunchOptions"] += '& %s "%s" "%s";' % (
+                app["LaunchOptions"] = '%s %s %%command%% "%s" "%s";' % (
+                    launch_options,
                     script,
                     wm_name,
                     wm_name_alt,
                 )
             else:
-                app["LaunchOptions"] += '& %s "%s";' % (script, wm_name)
+                app["LaunchOptions"] = '%s %s %%command%% "%s";' % (launch_options, script, wm_name)
         vdf.dump(loaded, open(conf_file, "w"), pretty=True)
 
 

--- a/sif.py
+++ b/sif.py
@@ -207,14 +207,19 @@ def fix_launch_option(app_id, wm_name, wm_name_alt=""):
             launch_options = app["LaunchOptions"].strip()
             script = str(WM_CLASS_FIXER_SCRIPT)
             if wm_name_alt:
-                app["LaunchOptions"] = '%s %s "%%command%%" "%s" "%s";' % (
+                app["LaunchOptions"] = '%s %s "%s" "%s" %%command%%;' % (
                     launch_options,
                     script,
                     wm_name,
                     wm_name_alt,
                 )
             else:
-                app["LaunchOptions"] = '%s %s "%%command%%" "%s";' % (launch_options, script, wm_name)
+                app["LaunchOptions"] = '%s %s "%s" "%s" %%command%%;' % (
+                    launch_options,
+                    script,
+                    wm_name,
+                    wm_name,
+                )
         vdf.dump(loaded, open(conf_file, "w"), pretty=True)
 
 
@@ -719,7 +724,7 @@ if __name__ == "__main__":
         if steam_detected:
             print_warning("\nSome games couldn't be fixed due to running Steam.\nExit Steam and try it again.")
         else:
-            print("\n * - added fix to game launch options")
+            print("\n * - added fix to game launch options. Please double check to ensure your launch options are correct.")
 
     if options.pretend:
         print_warning("\nNo changes were made because --pretend option was used.")

--- a/sif.py
+++ b/sif.py
@@ -207,14 +207,14 @@ def fix_launch_option(app_id, wm_name, wm_name_alt=""):
             launch_options = app["LaunchOptions"].strip()
             script = str(WM_CLASS_FIXER_SCRIPT)
             if wm_name_alt:
-                app["LaunchOptions"] = '%s %s %%command%% "%s" "%s";' % (
+                app["LaunchOptions"] = '%s %s "%%command%%" "%s" "%s";' % (
                     launch_options,
                     script,
                     wm_name,
                     wm_name_alt,
                 )
             else:
-                app["LaunchOptions"] = '%s %s %%command%% "%s";' % (launch_options, script, wm_name)
+                app["LaunchOptions"] = '%s %s "%%command%%" "%s";' % (launch_options, script, wm_name)
         vdf.dump(loaded, open(conf_file, "w"), pretty=True)
 
 
@@ -232,7 +232,8 @@ def restore_launch_options():
         for app_id in apps.keys():
             app = apps[app_id]
             if "LaunchOptions" in app.keys():
-                app["LaunchOptions"] = sub("&\\s/.*fix-wm-class\\.sh.*?;", "", app["LaunchOptions"])
+                app["LaunchOptions"] = sub("\\s/.*fix-wm-class\\.sh.*?;", " %command%", app["LaunchOptions"])
+                app["LaunchOptions"] = app["LaunchOptions"].strip()
         vdf.dump(loaded, open(conf_file, "w"), pretty=True)
 
 


### PR DESCRIPTION
The reason I check if reaper is running is because it is more reliable. Pillars seems to spawn multiple processes, and I'm not sure which to track, due to how it launches. There's also a delay between when reaper launches and when the game launches. However, reaper will always close when the game closes, so it's reliable in 99.9% of cases (if a user has disabled the steam wrapper though, I'm not sure what we can do). 

I'm new to Linux and bash, so let me know if this is inefficient.